### PR TITLE
healthd: Reinitialize mChargerNames for every battery update

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -325,10 +325,8 @@ static BatteryMonitor::PowerSupplyType readPowerSupplyType(const String8& path) 
     }
 
     auto ret = mapSysfsString(buf.c_str(), supplyTypeMap);
-    if (!ret) {
-        KLOG_WARNING(LOG_TAG, "Unknown power supply type '%s'\n", buf.c_str());
+    if (!ret)
         *ret = BatteryMonitor::ANDROID_POWER_SUPPLY_TYPE_UNKNOWN;
-    }
 
     return static_cast<BatteryMonitor::PowerSupplyType>(*ret);
 }
@@ -446,6 +444,40 @@ void BatteryMonitor::updateValues(void) {
         mHealthInfo->chargingState = getBatteryChargingState(buf.c_str());
 
     double MaxPower = 0;
+
+    // Rescan for the available charger types
+    std::unique_ptr<DIR, decltype(&closedir)> dir(opendir(POWER_SUPPLY_SYSFS_PATH), closedir);
+    if (dir == NULL) {
+        KLOG_ERROR(LOG_TAG, "Could not open %s\n", POWER_SUPPLY_SYSFS_PATH);
+    } else {
+        struct dirent* entry;
+        String8 path;
+
+        mChargerNames.clear();
+
+        while ((entry = readdir(dir.get()))) {
+            const char* name = entry->d_name;
+
+            if (!strcmp(name, ".") || !strcmp(name, ".."))
+                continue;
+
+            // Look for "type" file in each subdirectory
+            path.clear();
+            path.appendFormat("%s/%s/type", POWER_SUPPLY_SYSFS_PATH, name);
+            switch(readPowerSupplyType(path)) {
+            case ANDROID_POWER_SUPPLY_TYPE_AC:
+            case ANDROID_POWER_SUPPLY_TYPE_USB:
+            case ANDROID_POWER_SUPPLY_TYPE_WIRELESS:
+                path.clear();
+                path.appendFormat("%s/%s/online", POWER_SUPPLY_SYSFS_PATH, name);
+                if (access(path.string(), R_OK) == 0)
+                    mChargerNames.add(String8(name));
+                break;
+            default:
+                break;
+            }
+        }
+    }
 
     for (size_t i = 0; i < mChargerNames.size(); i++) {
         String8 path;


### PR DESCRIPTION
Booting up the device without usb, the kernel sets the usb power supply type as UNKNOWN. The type of usb power supply changes at run-time as various chargers are plugged in/out. However, healthd initilizes the charger list only at bootup. Change it such that it checks for charger type changes with every battery or usb uevent.

While at it, the kernel may have a power supply type which is not known to healthd. This is perfectly fine. Update healthd to not print a warning.

Change-Id: I2ec9f9a420ca61814d43c316b418ce94de3691bc

Former-commit-id: 08a453898adf2f5bfb594396d6d915d68ebb67b8
Change-Id: I7d5675b4e9a8a23228b0255071dd6965cdd43d6d


This fixes bug where system don't know that the device is being charged change has been merged in aospa 

https://gerrit.aospa.co/c/AOSPA/android_system_core/+/34969