### PR TITLE
liblp: Allow to flash on bigger block device

### DIFF
--- a/fs_mgr/liblp/builder.cpp
+++ b/fs_mgr/liblp/builder.cpp
@@ -1043,8 +1043,8 @@ bool MetadataBuilder::UpdateBlockDeviceInfo(size_t index, const BlockDeviceInfo&
     CHECK(index < block_devices_.size());
 
     LpMetadataBlockDevice& block_device = block_devices_[index];
-    if (device_info.size != block_device.size) {
-        LERROR << "Device size does not match (got " << device_info.size << ", expected "
+    if (device_info.size < block_device.size) {
+        LERROR << "Device size does not fit (got " << device_info.size << ", expected "
                << block_device.size << ")";
         return false;
     }

--- a/fs_mgr/liblp/writer.cpp
+++ b/fs_mgr/liblp/writer.cpp
@@ -138,8 +138,8 @@ static bool ValidateAndSerializeMetadata([[maybe_unused]] const IPartitionOpener
             PERROR << partition_name << ": ioctl";
             return false;
         }
-        if (info.size != block_device.size) {
-            LERROR << "Block device " << partition_name << " size mismatch (expected"
+        if (info.size < block_device.size) {
+            LERROR << "Block device " << partition_name << " size is too small (expected"
                    << block_device.size << ", got " << info.size << ")";
             return false;
         }


### PR DESCRIPTION
Needed for using Retrofit Dynamic Partitions on unified targets, which has different partition sizes on different devices.

Change-Id: I2b4c05401569ce5fc301ebafa7d130c3b0d87c64